### PR TITLE
Align docs and validation with the MDAD/MASH style guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,11 +106,11 @@ For mash-playbook users, use MySQL integration:
   vars:
     ghost_mail_enabled: true
     ghost_mail_options_host: 'localhost'
-    ghost_mail_options_auth_user: 'ghost@yourdomain.com'
+    ghost_mail_options_auth_user: 'ghost@mta.example.com'
     ghost_mail_options_auth_pass: '{{ vault_ghost_email_password }}'
-    ghost_mail_from: 'ghost@yourdomain.com'
+    ghost_mail_from: 'ghost@mta.example.com'
     ghost_mail_from_name: 'Ghost Blog'
-    ghost_hostname: 'blog.yourdomain.com'
+    ghost_hostname: 'blog.example.com'
     ghost_database_hostname: 'localhost'
     ghost_database_password: '{{ vault_ghost_db_password }}'
 ```

--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ Anything not covered by a dedicated variable (e.g. `spam`, `caching`, `klipy`, `
 can still be set via `ghost_environment_variables_additional_variables`, using Ghost's `__`-separated env var
 naming convention documented at <https://ghost.org/docs/config/>.
 
-## Mash-Playbook Integration
+## MASH playbook integration
 
 This role supports integration with the [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook) and includes email functionality. See [docs/mash-playbook-integration.md](docs/mash-playbook-integration.md) for detailed integration instructions.
 
-### Quick Start for Mash-Playbook
+### Quick start with the MASH playbook
 
 ```yaml
 - role: ghost
   vars:
     ghost_mail_enabled: true
     ghost_mail_options_host: 'localhost'
-    ghost_mail_options_auth_user: 'ghost@yourdomain.com'
+    ghost_mail_options_auth_user: 'ghost@mta.example.com'
     ghost_mail_options_auth_pass: '{{ vault_ghost_email_password }}'
-    ghost_mail_from: 'ghost@yourdomain.com'
+    ghost_mail_from: 'ghost@mta.example.com'
     ghost_mail_from_name: 'Ghost Blog'
-    ghost_hostname: 'blog.yourdomain.com'
+    ghost_hostname: 'blog.example.com'
     ghost_database_hostname: 'localhost'
     ghost_database_password: '{{ vault_ghost_db_password }}'
 ```

--- a/docs/mash-playbook-integration.md
+++ b/docs/mash-playbook-integration.md
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2025 Pavel Dimov <@sagat79>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Ghost Role for Mash-Playbook
+# Ghost role for the MASH playbook
 
 This Ghost Ansible role has been adapted for integration with the [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook) and supports email functionality.
 
@@ -16,7 +16,7 @@ This Ghost Ansible role has been adapted for integration with the [mash-playbook
 - **Reverse Proxy**: A reverse proxy server (such as Nginx or Traefik) is recommended for serving web requests and handling SSL termination.
 - **SMTP Service**: An SMTP server is needed for sending emails when mail functionality is enabled.
 
-## Mash-Playbook Integration
+## MASH playbook integration
 
 When used as part of the mash-playbook, this role integrates with email services to provide email functionality for Ghost.
 
@@ -31,13 +31,13 @@ ghost_mail_transport: 'SMTP'
 ghost_mail_options_host: 'localhost'
 ghost_mail_options_port: 587
 ghost_mail_options_secure: true
-ghost_mail_options_auth_user: 'ghost@yourdomain.com'
+ghost_mail_options_auth_user: 'ghost@mta.example.com'
 ghost_mail_options_auth_pass: 'your_password'
-ghost_mail_from: 'ghost@yourdomain.com'
+ghost_mail_from: 'ghost@mta.example.com'
 ghost_mail_from_name: 'Ghost Blog'
 ```
 
-### Email Integration
+### Email integration
 
 When `ghost_mail_enabled` is set to `true`, the role automatically configures Ghost to use SMTP for sending emails. This includes:
 
@@ -46,7 +46,7 @@ When `ghost_mail_enabled` is set to `true`, the role automatically configures Gh
 - TLS/SSL settings
 - From email and name configuration
 
-### Usage in Mash-Playbook
+### Usage with the MASH playbook
 
 Add this role to your mash-playbook configuration:
 
@@ -55,16 +55,16 @@ Add this role to your mash-playbook configuration:
   vars:
     ghost_mail_enabled: true
     ghost_mail_options_host: 'localhost'
-    ghost_mail_options_auth_user: 'ghost@yourdomain.com'
+    ghost_mail_options_auth_user: 'ghost@mta.example.com'
     ghost_mail_options_auth_pass: '{{ vault_ghost_email_password }}'
-    ghost_mail_from: 'ghost@yourdomain.com'
+    ghost_mail_from: 'ghost@mta.example.com'
     ghost_mail_from_name: 'Ghost Blog'
-    ghost_hostname: 'blog.yourdomain.com'
+    ghost_hostname: 'blog.example.com'
     ghost_database_hostname: 'localhost'
     ghost_database_password: '{{ vault_ghost_db_password }}'
 ```
 
-### Email Configuration
+### Email configuration
 
 The role automatically configures Ghost's email settings when mail is enabled:
 

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -10,6 +10,15 @@
     - install-all
     - install-ghost
   block:
+    - name: (Deprecation) Catch and report renamed settings
+      ansible.builtin.fail:
+        msg: >-
+          Your configuration contains a variable, which now has a different name.
+          Please change your configuration to rename the variable (`{{ item.old }}` -> `{{ item.new }}`).
+      when: "lookup('ansible.builtin.varnames', ('^' + item.old + '$'), wantlist=True) | length > 0"
+      with_items:
+        - { "old": "ghost_database_type", "new": "<removed — Ghost supports MySQL only; see the CHANGELOG migration guide>" }
+
     - name: Check if Ghost hostname is set
       ansible.builtin.fail:
         msg: "ghost_hostname must be set to a valid hostname"


### PR DESCRIPTION
- use the example.com placeholder domain everywhere (was yourdomain.com)
- per-service sender address example (ghost@mta.example.com)
- sentence-case headings and consistent MASH playbook naming
- deprecation validation for the removed ghost_database_type variable