### PR TITLE
Fix meta dependencies and UID/GID validation for mash-playbook integr…

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,7 +27,3 @@ galaxy_info:
     - docker
     - mashplaybook
     - email
-
-dependencies:
-  - role: devture.playbook_help
-  - role: devture.systemd_docker_base

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -27,12 +27,12 @@
     - name: Check if Ghost UID is set
       ansible.builtin.fail:
         msg: "ghost_uid must be set to a valid user ID"
-      when: ghost_uid | length == 0
+      when: ghost_uid | string | length == 0
 
     - name: Check if Ghost GID is set
       ansible.builtin.fail:
         msg: "ghost_gid must be set to a valid group ID"
-      when: ghost_gid | length == 0
+      when: ghost_gid | string | length == 0
 
     - name: Check if Ghost database hostname is set
       ansible.builtin.fail:


### PR DESCRIPTION
…ation

- meta/main.yml: drop the devture.playbook_help / devture.systemd_docker_base dependencies. mash-playbook includes roles by direct path (galaxy/<name>) rather than namespaced FQCN, and already runs those roles earlier in the play — the declared dependencies were unresolvable and broke even --syntax-check for the whole playbook whenever this role was present, regardless of ghost_enabled.
- tasks/validate_config.yml: cast ghost_uid/ghost_gid to string before the length check. With native Jinja type preservation (e.g. when set to "{{ mash_playbook_uid }}"), these arrive as int, and `| length` on an int raises instead of validating.

Found while running the multi-service (authentik + Ghost) test plan on a real host.